### PR TITLE
removing UserDetails dependency

### DIFF
--- a/src/main/java/cz/polankam/security/acl/AclPermissionEvaluator.java
+++ b/src/main/java/cz/polankam/security/acl/AclPermissionEvaluator.java
@@ -5,7 +5,6 @@ import cz.polankam.security.acl.exceptions.ResourceNotFoundException;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -107,15 +106,11 @@ public class AclPermissionEvaluator implements PermissionEvaluator {
 
     private boolean hasPermissionInternal(Authentication authentication, Object targetDomainObject, Object permission) {
         if (authentication == null ||
-                !(authentication.getPrincipal() instanceof UserDetails) ||
-                !(targetDomainObject instanceof String) ||
-                !(permission instanceof String)) {
+                !(authentication.getPrincipal() instanceof Authorized user) ||
+                !(targetDomainObject instanceof String targetResource) ||
+                !(permission instanceof String permissionString)) {
             return false;
         }
-
-        UserDetails user = (UserDetails) authentication.getPrincipal();
-        String targetResource = (String) targetDomainObject;
-        String permissionString = (String) permission;
 
         // check the permissions against all user roles
         for (GrantedAuthority authority : user.getAuthorities()) {
@@ -142,13 +137,10 @@ public class AclPermissionEvaluator implements PermissionEvaluator {
 
     private boolean hasPermissionInternal(Authentication authentication, Serializable targetId, String targetType, Object permission) {
         if (authentication == null ||
-                !(authentication.getPrincipal() instanceof UserDetails) ||
-                !(permission instanceof String)) {
+                !(authentication.getPrincipal() instanceof Authorized user) ||
+                !(permission instanceof String permissionString)) {
             return false;
         }
-
-        UserDetails user = (UserDetails) authentication.getPrincipal();
-        String permissionString = (String) permission;
 
         // check the permissions against all user roles
         for (GrantedAuthority authority : user.getAuthorities()) {

--- a/src/main/java/cz/polankam/security/acl/Authorized.java
+++ b/src/main/java/cz/polankam/security/acl/Authorized.java
@@ -1,0 +1,14 @@
+package cz.polankam.security.acl;
+
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+/**
+ * Interface for marking an entity that may have authority.
+ * <p>
+ * Created by Alexander Tsapyrin
+ */
+public interface Authorized {
+    Collection<? extends GrantedAuthority> getAuthorities();
+}

--- a/src/main/java/cz/polankam/security/acl/conditions/AndCondition.java
+++ b/src/main/java/cz/polankam/security/acl/conditions/AndCondition.java
@@ -1,6 +1,6 @@
 package cz.polankam.security.acl.conditions;
 
-import org.springframework.security.core.userdetails.UserDetails;
+import cz.polankam.security.acl.Authorized;
 
 import java.util.Arrays;
 
@@ -30,7 +30,7 @@ final class AndCondition<T> implements PermissionCondition<T> {
 
 
     @Override
-    public boolean test(UserDetails user, T resource) {
+    public boolean test(Authorized user, T resource) {
         return Arrays.stream(conditions).allMatch(condition -> condition.test(user, resource));
     }
 }

--- a/src/main/java/cz/polankam/security/acl/conditions/OrCondition.java
+++ b/src/main/java/cz/polankam/security/acl/conditions/OrCondition.java
@@ -1,6 +1,6 @@
 package cz.polankam.security.acl.conditions;
 
-import org.springframework.security.core.userdetails.UserDetails;
+import cz.polankam.security.acl.Authorized;
 
 import java.util.Arrays;
 
@@ -30,7 +30,7 @@ final class OrCondition<T> implements PermissionCondition<T> {
 
 
     @Override
-    public boolean test(UserDetails user, T resource) {
+    public boolean test(Authorized user, T resource) {
         return Arrays.stream(conditions).anyMatch(condition -> condition.test(user, resource));
     }
 }

--- a/src/main/java/cz/polankam/security/acl/conditions/PermissionCondition.java
+++ b/src/main/java/cz/polankam/security/acl/conditions/PermissionCondition.java
@@ -1,6 +1,6 @@
 package cz.polankam.security.acl.conditions;
 
-import org.springframework.security.core.userdetails.UserDetails;
+import cz.polankam.security.acl.Authorized;
 
 /**
  * Functional interface for permission conditions. Main test method is used for
@@ -18,5 +18,5 @@ public interface PermissionCondition<T> {
      * @param resource resource against which condition is evaluated
      * @return true if condition is truthy, false otherwise
      */
-    boolean test(UserDetails user, T resource);
+    boolean test(Authorized user, T resource);
 }

--- a/src/main/java/cz/polankam/security/acl/conditions/TrueCondition.java
+++ b/src/main/java/cz/polankam/security/acl/conditions/TrueCondition.java
@@ -1,6 +1,6 @@
 package cz.polankam.security.acl.conditions;
 
-import org.springframework.security.core.userdetails.UserDetails;
+import cz.polankam.security.acl.Authorized;
 
 /**
  * Condition which is always validated to true.
@@ -12,7 +12,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 final class TrueCondition<T> implements PermissionCondition<T> {
 
     @Override
-    public boolean test(UserDetails user, T resource) {
+    public boolean test(Authorized user, T resource) {
         return true;
     }
 }

--- a/src/test/java/cz/polankam/security/acl/test_utils/DemoGroupConditions.java
+++ b/src/test/java/cz/polankam/security/acl/test_utils/DemoGroupConditions.java
@@ -1,24 +1,24 @@
 package cz.polankam.security.acl.test_utils;
 
-import org.springframework.security.core.userdetails.UserDetails;
+import cz.polankam.security.acl.Authorized;
 
 public class DemoGroupConditions {
 
-    public static boolean isMember(UserDetails userDetails, DemoGroup resource) {
-        if (!(userDetails instanceof DemoUser) ||
+    public static boolean isMember(Authorized user, DemoGroup resource) {
+        if (!(user instanceof DemoUser) ||
                 resource == null) {
             return false;
         }
 
-        return resource.isMember((DemoUser) userDetails);
+        return resource.isMember((DemoUser) user);
     }
 
-    public static boolean isManager(UserDetails userDetails, DemoGroup resource) {
-        if (!(userDetails instanceof DemoUser) ||
+    public static boolean isManager(Authorized user, DemoGroup resource) {
+        if (!(user instanceof DemoUser) ||
                 resource == null) {
             return false;
         }
 
-        return resource.isManager((DemoUser) userDetails);
+        return resource.isManager((DemoUser) user);
     }
 }

--- a/src/test/java/cz/polankam/security/acl/test_utils/DemoPermissionsService.java
+++ b/src/test/java/cz/polankam/security/acl/test_utils/DemoPermissionsService.java
@@ -1,10 +1,10 @@
 package cz.polankam.security.acl.test_utils;
 
+import cz.polankam.security.acl.Authorized;
 import cz.polankam.security.acl.IPermissionsService;
 import cz.polankam.security.acl.IResourceRepository;
 import cz.polankam.security.acl.Role;
 import cz.polankam.security.acl.conditions.ConditionsFactory;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,7 +38,7 @@ public class DemoPermissionsService implements IPermissionsService {
                 true,
                 "group",
                 ConditionsFactory.or(
-                        (UserDetails userDetails, DemoGroup group) -> false, // just to show off or condition
+                        (Authorized authorizedUser, DemoGroup group) -> false, // just to show off or condition
                         DemoGroupConditions::isManager
                 ),
                 "edit"

--- a/src/test/java/cz/polankam/security/acl/test_utils/DemoUser.java
+++ b/src/test/java/cz/polankam/security/acl/test_utils/DemoUser.java
@@ -1,8 +1,8 @@
 package cz.polankam.security.acl.test_utils;
 
+import cz.polankam.security.acl.Authorized;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -10,7 +10,7 @@ import java.util.Collections;
 /**
  * Demo user entity.
  */
-public class DemoUser implements UserDetails {
+public class DemoUser implements Authorized {
 
     private String username;
     private String role;
@@ -20,39 +20,12 @@ public class DemoUser implements UserDetails {
         this.role = role;
     }
 
-
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority(role));
-    }
-
-    @Override
-    public String getPassword() {
-        return null;
-    }
-
-    @Override
     public String getUsername() {
         return username;
     }
 
     @Override
-    public boolean isAccountNonExpired() {
-        return false;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return false;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return false;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return false;
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority(role));
     }
 }


### PR DESCRIPTION
Using the UserDetails interface is redundant. Real applications often use other implementations, which in turn do not implement UserDetails.